### PR TITLE
Update alpine to 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 RUN apk --no-cache add dnsmasq
 EXPOSE 53 53/udp
 ENTRYPOINT ["dnsmasq", "-k"]


### PR DESCRIPTION
Alpine 3.3 has "vulnerabilities" according to Docker Hub.
Check it out: https://hub.docker.com/r/library/alpine/tags/3.3/

It looks important to upgrade this dnsmasq image to alpine 3.4 .
