### PR TITLE
Disable open resolver.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.4
 RUN apk --no-cache add dnsmasq
 EXPOSE 53 53/udp
-ENTRYPOINT ["dnsmasq", "-k"]
+ENTRYPOINT ["dnsmasq", "--local-service" ,"-k"]


### PR DESCRIPTION
Accept DNS queries only from hosts whose address is on a local subnet, ie a subnet for which an interface exists on the server.

Stops dnsmasq from being vulnerable to DNS Amplification Attack.