### PR TITLE
Don't drop root privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.4
 RUN apk --no-cache add dnsmasq
 EXPOSE 53 53/udp
-ENTRYPOINT ["dnsmasq", "-k"]
+ENTRYPOINT ["dnsmasq", "-k", "--user=root"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It is usually a good idea to use a tag other than `latest` if you are using this
 * `andyshinn/dnsmasq:2.75`: dnsmasq 2.75 based on Alpine 3.3
 * `andyshinn/dnsmasq:2.76`: dnsmasq 2.76 based on Alpine 3.4
 
-[dnsmasq][dnsmasq] requires `NET_ADMIN` capabilities to run correctly. Start it with something like `docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN andyshinn/dnsmasq:2.75`.
+The configuration is all handled on the command line (no wrapper scripts here). The `ENTRYPOINT` is `dnsmasq -k --user=root` to keep it running in the foreground without trying to drop root privileges.  We keep dnsmasq running as root to avoid the requirement for `NET_ADMIN` capabilites being required.
 
-The configuration is all handled on the command line (no wrapper scripts here). The `ENTRYPOINT` is `dnsmasq -k` to keep it running in the foreground. If you wanted to send requests for an internal domain (such as Consul) you can forward the requests upstream using something like `docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN andyshinn/dnsmasq:2.75 -S /consul/10.17.0.2`. This will send a request for `redis.service.consul` to `10.17.0.2`
+If you wanted to send requests for an internal domain (such as Consul) you can forward the requests upstream using something like `docker run -p 53:53/tcp -p 53:53/udp andyshinn/dnsmasq:2.75 -S /consul/10.17.0.2`. This will send a request for `redis.service.consul` to `10.17.0.2`
 
 As this is a very barebones entrypoint with just enough to run in the foreground, there is no logging enabled by default. To send logging to stdout you can add `--log-facility=-` as an option.
 


### PR DESCRIPTION
Given that we're already running in a contained environment, requiring the `NET_ADMIN` capability so that an unprivileged user inside of the container can control the interfaces for the purposes of DHCP makes not dropping privs and just continuing to run as root seem like a reasonable default to me.

What do you think @andyshinn ?