### PR TITLE
Support additional option for dnsmasq command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:edge
 RUN apk --no-cache add dnsmasq
 EXPOSE 53 53/udp
-ENTRYPOINT ["dnsmasq", "-k"]
+ENTRYPOINT ["sh", "-c", "dnsmasq -k $OPTION"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  dnsmasq:
+    build: .
+    restart: always
+    container_name: dnsmasq
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    cap_add:
+      - NET_ADMIN
+    extra_hosts:
+      - "your.host.name.com:192.168.1.42"
+    # environment:
+    #   - OPTION=--no-resolv


### PR DESCRIPTION
Start dnsmasq with options by `OPTION` environment variable. 
And added `docker-compose.yml` for easy to use.