### PR TITLE
use dumb-init and enable ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=edge
 FROM alpine:$ALPINE_VERSION
 RUN apk --no-cache add dnsmasq-dnssec dumb-init
-EXPOSE 53 53/udp
+EXPOSE 53 53/udp 67/udp 69/udp
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/sbin/dnsmasq", "-k"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=edge
 FROM alpine:$ALPINE_VERSION
-RUN apk --no-cache add dnsmasq-dnssec
+RUN apk --no-cache add dnsmasq-dnssec dumb-init
 EXPOSE 53 53/udp
-ENTRYPOINT ["/usr/sbin/dnsmasq", "-k"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/sbin/dnsmasq", "-k"]


### PR DESCRIPTION
Using dumb-init helps with proper signal handling and zombies collection.

Enabling DHCP and TFTP ports for anybody that needs.